### PR TITLE
Video fixation msl

### DIFF
--- a/src/sessions/ses-friends-s6-fixations.py
+++ b/src/sessions/ses-friends-s6-fixations.py
@@ -2,6 +2,7 @@ from ..tasks import video
 
 TASKS = []
 
+
 # de-comment line 7 when done piloting
 #for episode in list(range(1, 4)): # to test, just not to download the entire season for local tests
 for episode in list(range(1, 16))+list(range(17,25)):
@@ -18,3 +19,31 @@ for episode in list(range(1, 16))+list(range(17,25)):
                 name="task-friends-s6e%d%s-fixations" % (episode, segment),
             )
         )
+'''
+
+TASKS.append(
+    video.SingleVideo(
+        "/home/labopb/Documents/Marie/neuromod/friends_eyetrack/video_stimuli/friends_s06e08a_extract2.mp4",
+        #"data/videos/friends/s6/friends_s06e%02d%s.mkv" % (episode, segment),
+        aspect_ratio=4 / 3.0,
+        startend_fixduration=0.0,#2.0,
+        inmovie_fixations=True,
+        infix_freq=20,
+        infix_dur=1.5,
+        name="task-friends-s6e08a2-fixations",
+    )
+)
+
+TASKS.append(
+    video.SingleVideo(
+        "/home/labopb/Documents/Marie/neuromod/friends_eyetrack/video_stimuli/friends_s06e08a_extract.mp4",
+        #"data/videos/friends/s6/friends_s06e%02d%s.mkv" % (episode, segment),
+        aspect_ratio=4 / 3.0,
+        startend_fixduration=0.0,#2.0,
+        inmovie_fixations=True,
+        infix_freq=20,
+        infix_dur=1.5,
+        name="task-friends-s6e08a1-fixations",
+    )
+)
+'''

--- a/src/sessions/ses-friends-s6-fixations.py
+++ b/src/sessions/ses-friends-s6-fixations.py
@@ -19,31 +19,3 @@ for episode in list(range(1, 16))+list(range(17,25)):
                 name="task-friends-s6e%d%s-fixations" % (episode, segment),
             )
         )
-'''
-
-TASKS.append(
-    video.SingleVideo(
-        "/home/labopb/Documents/Marie/neuromod/friends_eyetrack/video_stimuli/friends_s06e08a_extract2.mp4",
-        #"data/videos/friends/s6/friends_s06e%02d%s.mkv" % (episode, segment),
-        aspect_ratio=4 / 3.0,
-        startend_fixduration=0.0,#2.0,
-        inmovie_fixations=True,
-        infix_freq=20,
-        infix_dur=1.5,
-        name="task-friends-s6e08a2-fixations",
-    )
-)
-
-TASKS.append(
-    video.SingleVideo(
-        "/home/labopb/Documents/Marie/neuromod/friends_eyetrack/video_stimuli/friends_s06e08a_extract.mp4",
-        #"data/videos/friends/s6/friends_s06e%02d%s.mkv" % (episode, segment),
-        aspect_ratio=4 / 3.0,
-        startend_fixduration=0.0,#2.0,
-        inmovie_fixations=True,
-        infix_freq=20,
-        infix_dur=1.5,
-        name="task-friends-s6e08a1-fixations",
-    )
-)
-'''

--- a/src/sessions/ses-movie10-fixations1.py
+++ b/src/sessions/ses-movie10-fixations1.py
@@ -1,0 +1,55 @@
+from ..tasks import images, video, memory, task_base
+
+TASKS = []
+
+seg_idx = 6
+TASKS.append(
+    video.SingleVideo(
+        "data/videos/bourne_supremacy/bourne_supremacy_seg%02d.mkv" % seg_idx,
+        aspect_ratio=372 / 157,
+        startend_fixduration=0.0,#2.0,
+        inmovie_fixations=True,
+        infix_freq=20,
+        infix_dur=1.5,
+        name="bourne_supremacy_seg-%d-fixations" % seg_idx,
+    )
+)
+
+seg_idx = 4
+TASKS.append(
+    video.SingleVideo(
+        "data/videos/life1/life1_seg%02d.mkv" % seg_idx,
+        aspect_ratio=12 / 5,
+        startend_fixduration=0.0,#2.0,
+        inmovie_fixations=True,
+        infix_freq=20,
+        infix_dur=1.5,
+        name="life1_seg-%d-fixations" % seg_idx,
+    )
+)
+
+seg_idx = 7
+TASKS.append(
+    video.SingleVideo(
+        "data/videos/hidden_figures/hidden_figures_seg%02d.mkv" % seg_idx,
+        aspect_ratio=12 / 5,
+        startend_fixduration=0.0,#2.0,
+        inmovie_fixations=True,
+        infix_freq=20,
+        infix_dur=1.5,
+        name="hidden_figures_seg-%d-fixations" % seg_idx,
+    )
+)
+
+seg_idx = 10
+TASKS.append(
+    video.SingleVideo(
+        "data/videos/the_wolf_of_wall_street/the_wolf_of_wall_street_seg%02d.mkv" % seg_idx,
+        aspect_ratio=12 / 5,
+        startend_fixduration=0.0,#2.0,
+        inmovie_fixations=True,
+        infix_freq=20,
+        infix_dur=1.5,
+        name="the_wolf_of_wall_street_seg-%d-fixations" % seg_idx,
+    )
+)

--- a/src/sessions/ses-movie10-fixations2.py
+++ b/src/sessions/ses-movie10-fixations2.py
@@ -1,0 +1,55 @@
+from ..tasks import images, video, memory, task_base
+
+TASKS = []
+
+seg_idx = 7
+TASKS.append(
+    video.SingleVideo(
+        "data/videos/bourne_supremacy/bourne_supremacy_seg%02d.mkv" % seg_idx,
+        aspect_ratio=372 / 157,
+        startend_fixduration=0.0,#2.0,
+        inmovie_fixations=True,
+        infix_freq=20,
+        infix_dur=1.5,
+        name="bourne_supremacy_seg-%d-fixations" % seg_idx,
+    )
+)
+
+seg_idx = 5
+TASKS.append(
+    video.SingleVideo(
+        "data/videos/life1/life1_seg%02d.mkv" % seg_idx,
+        aspect_ratio=12 / 5,
+        startend_fixduration=0.0,#2.0,
+        inmovie_fixations=True,
+        infix_freq=20,
+        infix_dur=1.5,
+        name="life1_seg-%d-fixations" % seg_idx,
+    )
+)
+
+seg_idx = 8
+TASKS.append(
+    video.SingleVideo(
+        "data/videos/hidden_figures/hidden_figures_seg%02d.mkv" % seg_idx,
+        aspect_ratio=12 / 5,
+        startend_fixduration=0.0,#2.0,
+        inmovie_fixations=True,
+        infix_freq=20,
+        infix_dur=1.5,
+        name="hidden_figures_seg-%d-fixations" % seg_idx,
+    )
+)
+
+seg_idx = 11
+TASKS.append(
+    video.SingleVideo(
+        "data/videos/the_wolf_of_wall_street/the_wolf_of_wall_street_seg%02d.mkv" % seg_idx,
+        aspect_ratio=12 / 5,
+        startend_fixduration=0.0,#2.0,
+        inmovie_fixations=True,
+        infix_freq=20,
+        infix_dur=1.5,
+        name="the_wolf_of_wall_street_seg-%d-fixations" % seg_idx,
+    )
+)

--- a/src/tasks/video.py
+++ b/src/tasks/video.py
@@ -2,6 +2,7 @@ import os, sys, time
 
 #import psychopy
 #psychopy.prefs.hardware['audioLib'] = ['PTB', 'sounddevice', 'pyo','pygame'] # for local dev (laptop)
+import numpy as np
 from psychopy import visual, core, data, logging
 from .task_base import Task
 
@@ -79,6 +80,22 @@ and fixate the dot whenever it appears."""
                                         colorSpace='rgb', fillColor=(-.58, -.58, -.58)) # (54, 54, 54) on 0-255 scale
             self.black_bgd = visual.Rect(exp_win, size=exp_win.size, lineWidth=0,
                                         colorSpace='rgb', fillColor=(-1, -1, -1))
+            self.startcue = visual.Circle(exp_win, units='pix', pos=(0,0), radius=10, lineWidth=0, fillColor=(1, 1, 1))
+            self.markers = np.asarray(
+                [
+                    (0.5, 0.5),
+                    (0, 0.5),
+                    (0.0, 1.0),
+                    (0.5, 1.0),
+                    (1.0, 1.0),
+                    (1.0, 0.5),
+                    (1.0, 0.0),
+                    (0.5, 0.0),
+                    (0.0, 0.0),
+                ]
+            )
+            self.markers_order = np.random.permutation(np.arange(len(self.markers)))
+            self.marker_duration = 1.5 # 60 fps, 4s = 240; 60fps, 1.5s = 90 frames
 
         #self.movie_stim = visual.MovieStim3(exp_win, self.filepath, units="pix")
         self.movie_stim = visual.MovieStim2(exp_win, self.filepath, units="pix")
@@ -114,7 +131,9 @@ and fixate the dot whenever it appears."""
         mv_FPS = self.movie_stim.getFPS()
         fixation_on = False  # "switch" to determine fixation onset/offset time for logs
         self.movie_stim.play()
+
         while self.movie_stim.status != visual.FINISHED:
+        #while self.movie_stim.getCurrentFrameNumber() < 200:
             #exp_win.clearBuffer(color=True, depth=True)
             self.movie_stim.draw(exp_win)
             next_frame_time = self.movie_stim.getCurrentFrameTime()
@@ -178,8 +197,61 @@ and fixate the dot whenever it appears."""
 
             yield False
 
+        self.movie_stim.pause()
+
+        if self._inmovie_fixations:
+            window_size_frame = exp_win.size - 100 * 2
+            instruction_text = """Eyetracker Validation"""
+            screen_text = visual.TextStim(
+                exp_win,
+                text=instruction_text,
+                alignText="center",
+                color="white",
+                wrapWidth=config.WRAP_WIDTH,
+            )
+            for frameN in range(config.FRAME_RATE * 2):
+                screen_text.draw(exp_win)
+                if ctl_win:
+                    screen_text.draw(ctl_win)
+                yield True
+
+            exp_win.logOnFlip(
+                level=logging.EXP, msg=" gaze validation: starting at %f" % time.time())
+
+            for frameN in range(config.FRAME_RATE * 1):
+                self.startcue.draw(exp_win)
+                if ctl_win:
+                    self.startcue.draw(ctl_win)
+                yield True
+
+            for site_id in self.markers_order:
+                marker_pos = self.markers[site_id]
+                pos = (marker_pos - 0.5) * window_size_frame # remove 0.5 since 0, 0 is the middle in psychopy
+
+                for stim in self.fixation_dot:
+                    stim.pos = pos
+
+                exp_win.logOnFlip(
+                    level=logging.EXP,
+                    msg="marker position,%f,%f,%d,%d starting at %f"
+                    % (marker_pos[0], marker_pos[1], pos[0], pos[1], time.time()))
+
+                for f in range(int(config.FRAME_RATE * self.marker_duration)):
+                    for stim in self.fixation_dot:
+                        stim.draw(exp_win)
+                        if ctl_win:
+                            stim.draw(ctl_win)
+                    yield True
+
+                exp_win.logOnFlip(
+                    level=logging.EXP,
+                    msg="marker position,%f,%f,%d,%d ending at %f"
+                    % (marker_pos[0], marker_pos[1], pos[0], pos[1], time.time()))
+
+
     def _stop(self, exp_win, ctl_win):
         self.movie_stim.stop()
+
         for frameN in range(config.FRAME_RATE * FADE_TO_GREY_DURATION):
             grey = [float(frameN) / config.FRAME_RATE / FADE_TO_GREY_DURATION - 1] * 3
             exp_win.setColor(grey, colorSpace='rgb')


### PR DESCRIPTION
I added a quick 9-pt validation routine at the end of each Friends+Fixations run (within task's "run" function) to gather extra drift metrics outside the center of the screen. No need to add scan time to the protocol since I only need the additional eye-tracking data
 
I'd like to test out the code in the correct env before deploying it to scan, or merging onto the main branch: line 135 on src/tasks/video.py keeps crashing the script on my laptop. 
https://github.com/courtois-neuromod/task_stimuli/blob/1e3a841d1e50c9f054a9be7576d2fc5ffd6885da/src/tasks/video.py#L135

When the script plays the movie, it skips a bunch of frames at the very end of the video, so it does not detect when the video is finished (movie object's status not properly updated), and then the script crashes when it runs out of movie frames to draw. Since the task runs fine in the scanner at the moment, that's probably not an issue outside my local env, but I wouldn't mind a sanity check.  

