### PR TITLE
Add dockerfile for task development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,11 +35,8 @@ ENV GI_TYPELIB_PATH=/usr/local/lib/x86_64-linux-gnu/girepository-1.0/
 ENTRYPOINT ["/entrypoint.sh"]
 
 COPY . /src/task_stimuli
-
 RUN pip3 install -r /src/task_stimuli/requirements.txt
-
 COPY ./docker/.env.docker /src/task_stimuli/.env
-
 RUN pip install python-vlc==3.0.11115
 
 WORKDIR /src/task_stimuli/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+FROM ubuntu:20.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+  && apt-get -y install gosu swig python3-wxgtk4.0 python3-pip python3-minimal x11-xserver-utils wget qtbase5-dev libsdl2-2.0-0 libusb-1.0-0-dev portaudio19-dev libasound2-dev pulseaudio libpulse-dev\
+  && apt-get -y install pkg-config git cmake build-essential nasm wget python3-setuptools libusb-1.0-0-dev  python3-dev python3-pip python3-numpy python3-scipy libglew-dev libtbb-dev \
+     libavformat-dev libavcodec-dev libavdevice-dev libavutil-dev libswscale-dev libavresample-dev ffmpeg x264 x265 libportaudio2 portaudio19-dev \
+     python3-opencv libopencv-dev libeigen3-dev \
+  && apt-get autoremove && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update \
+  && apt-get -y install libxml2-dev libglib2.0-dev libusb-1.0-0-dev gobject-introspection \
+     libgtk-3-dev gtk-doc-tools xsltproc libgstreamer1.0-dev \
+     libgstreamer-plugins-base1.0-dev libgstreamer-plugins-good1.0-dev \
+     libgirepository1.0-dev gettext ninja-build vlc libvlc-dev\
+  && apt-get autoremove && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /src/task_stimuli
+
+RUN pip3 install --upgrade meson numpy scipy ipython pip
+COPY ./docker/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib/x86_64-linux-gnu
+
+RUN apt-get update \
+  && apt-get -y install gdb net-tools\
+  && apt-get autoremove && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-binary :all: --force-reinstall pyzmq
+
+ENV GI_TYPELIB_PATH=/usr/local/lib/x86_64-linux-gnu/girepository-1.0/
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+COPY . /src/task_stimuli
+
+RUN pip3 install -r /src/task_stimuli/requirements.txt
+
+COPY ./docker/.env.docker /src/task_stimuli/.env
+
+RUN pip install python-vlc==3.0.11115
+
+WORKDIR /src/task_stimuli/

--- a/README.md
+++ b/README.md
@@ -66,6 +66,24 @@ You can create new sessions by adding a `ses-xxxx.py` file in `src/sessions` fol
 Each file only create a `TASKS` list of task subclasses instances, that is loaded by the script and ran in the provided order.
 Check the existing files for examples.
 
+## Build the docker container without eyetracking and other extra hardware for task development
+
+Build the container:
+
+```bash
+docker build --no-cache -t task_stimuli:dev .
+```
+
+Example commend to run the task with `run_docker_dev.sh`:
+
+```bash
+bash run_docker_dev.sh --subject test --session testsession --tasks mytask -o /path/to/task/output/directory`
+```
+
+The script `run_docker_dev.sh` will bind the `src` directory to the Docker image and set up other variables needed.
+
+**`docker/` contains files for container for testing eye tracker and other shared files for docker build.**
+
 ## How to interact with the software:
 
 ### stimuli

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 PsychoPy==2020.2.4.post1
 gym-retro
 pandas>=1.1.1, <1.4.0
+numpy<1.24.0
 python-dotenv
 tqdm>=4.60.0
 textdistance

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-PsychoPy>=2020.2.4.post1
+PsychoPy==2020.2.4.post1
 gym-retro
-pandas>=1.1.1
+pandas>=1.1.1, <1.4.0
 python-dotenv
 tqdm>=4.60.0
 textdistance

--- a/run_docker_dev.sh
+++ b/run_docker_dev.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+docker run \
+  --network host \
+  --device=/dev/dri \
+  --device=/dev/snd  \
+  -v $PWD/src:/src/task_stimuli/src \
+  -v /run/user/1000/pulse:/run/user/1000/pulse \
+  -v $PWD/data:/src/task_stimuli/data \
+  -v ~/data/task_stimuli/test_docker:/data \
+  -e HOST_UID=$(id -u) \
+  -e HOST_GID=$(id -g) \
+  -e DISPLAY \
+  -v /tmp/.X11-unix:/tmp/.X11-unix \
+  task_stimuli:dev \
+  python3 main.py $@


### PR DESCRIPTION
Feel free to merge or disregard this PR!

Here's the dockerfile I used for developing the ICM task. 
It removes all the eyetracking related things.
It might be useful for the future if people refuse to install psychopy, like me. 

I locked the psychopy version to `2020.2.4.post1` and made changes to requirements to make things work. Psychopy dependency is almost changing every time they have an update. If we want to upgrade psychopy, it's better to test before changing things. 